### PR TITLE
Remove fix of broken json

### DIFF
--- a/R/login.R
+++ b/R/login.R
@@ -218,8 +218,7 @@ get_garmin_data <- function(username, password, start_date, end_date, number_of_
   disp_json <- regmatches(disp_resp,
                           regexpr('{\"*.*\\"}', disp_resp, perl = TRUE))
   disp_new <- gsub('\\\\\"', '"', disp_json)
-  # as of 2020-12-28 this no longer works without the paste... used to work without..
-  display_preferences <- jsonlite::fromJSON(paste0(disp_new, "}"))
+  display_preferences <- jsonlite::fromJSON(disp_new)
   display_name <- display_preferences$displayName
 
 


### PR DESCRIPTION
Looks like the patch added 202-12-28 is not only not needed, but is now a problem.

Without this patch I get:

```
> get_garmin_data(...)
Error: parse error: trailing garbage
          :null,"preferredLocale":"da"}}
                     (right here) ------^
```
